### PR TITLE
fix: Centered text for loading message in MapPage component

### DIFF
--- a/src/components/pages/map/MapPage.tsx
+++ b/src/components/pages/map/MapPage.tsx
@@ -79,7 +79,7 @@ export default function MapPage() {
             <div className="flex flex-col justify-center items-center w-screen h-screen p-5 md:p-0">
                 <div className="grid justify-items-center gap-5">
                     <h3 className="text-4xl">Loading...</h3>
-                    <h3 className="text-2xl">
+                    <h3 className="text-2xl text-center">
                         Fetching positions from the database
                     </h3>
                 </div>


### PR DESCRIPTION
# Tasks

- [x] Centered text for loading message in MapPage component
